### PR TITLE
Update index.md

### DIFF
--- a/supporters/index.md
+++ b/supporters/index.md
@@ -8,7 +8,7 @@ title: Support for STIX
 
 Please contact <stix@mitre.org> to request inclusion or modification.
 
-For User Communities, please include your community name, basic information about how you use STIX and/or TAXII, and a public reference that we can cite. For Products and Services, please include the product name, organization name, basic information about how you use STIX and/or TAXII, and a public reference that we can cite.
+For User Communities, please include your community name, basic information about how you use STIX and/or TAXII, and a public reference URL that we can cite. For Products and Services, please include the product name, organization name, basic information about how you use STIX and/or TAXII, and a public reference URL that we can cite.
 
 ## User Communities
 These organizations have publicly announced support for STIX and/or TAXII. 
@@ -17,6 +17,7 @@ These organizations have publicly announced support for STIX and/or TAXII.
 |---|---|---|---|---|---|---|---|
 |[Cyber Threat XChange (CTX)](https://hitrustalliance.net/cyber-threat-xchange/)|[Health Information Trust Alliance (HITRUST)](https://hitrustalliance.net)|Automates process of collecting and analyzing cyber threats and distributing actionable indicators|&#x2713;|&#x2713;|[Press Release](http://hitrustalliance.net/content/uploads/2014/10/Cyber-Threat-Xchange_Press-Release_final-for-wire.pdf)|
 |[hailataxii.com Repository of Open Source Cyber Threat Intelligence Feeds in STIX Format](http://hailataxii.com/)|[Hail a TAXII](http://hailataxii.com)|Repository of open source cyber threat intelligence feeds in STIX format|&#x2713;|&#x2713;|Cited as product features on website|
+|[ICS-ISAC](http://ics-isac.org/)|[Industrial Control System Information Sharing and Analysis Center (ICS-ISAC)](http://ics-isac.org/)|ICS-ISAC brings together infrastructure stakeholder to improve cybersecurity knowledge sharing. ICS-ISAC’s virtual SoltraEdge server, which includes STIX and TAXII interoperability, provides real-time information sharing for members|&#x2713;|&#x2713;|[Cited as features on website](http://ics-isac.org/blog/ics-isac-soltra-edge-taxii-server/)
 |NH-ISAC National Health Cybersecurity Intelligence Platform|[National Health Information Sharing & Analysis Center (NH-ISAC)](http://www.nhisac.org/)|Automating cybersecurity "actionable" threat intelligence, with STIX and TAXII interoperability, powered by Soltra-Edge and Vorstack|&#x2713;|&#x2713;|[Press Release](http://www.nhisac.org/blog/the-national-health-isac-and-the-center-for-internet-security-partner-to-strengthen-national-healthcare-public-health-cybersecurity-resilience/)|
 
 ## Products and Services
@@ -24,7 +25,9 @@ Many vendors have implemented STIX in their products and services.
 
 |Offering|Vendor|Type|STIX|TAXII|Reference|
 |---|---|---|---|---|---|---|---|
+|[Advanced Threat Prevention](http://www.checkpoint.com/products-solutions/threat-prevention/advanced-threat-prevention/index.html)|[Check Point Software Technology Ltd.](http://www.checkpoint.com)|ATP allows users to import indicators into threat prevention technologies, anti-bot, anti-virus, with an interface to upload STIX-formatted messages containing indicators into threat indicator database|&#x2713;|-|[Cited as product feature in “Threat Prevention R77 Versions Administration Guide](https://dl3.checkpoint.com/paid/3d/3d62cf0c986c24b64f9e7ec79ce386b1/CP_R77_ThreatPrevention_AdminGuide.pdf?HashKey=1428964311_7641271c918302c960d1d86f3af08817&xtn=.pdf)”|
 |Adaptive Threat Protection Solution|[Tripwire, Inc.](http://www.tripwire.com/)|Integrates peer and community threat feeds, leveraging STIX and TAXII standards, and other commercial threat intelligence services|&#x2713;|&#x2713;|[Press Release](http://www.tripwire.com/company/news/press-release/tripwire-expands-adaptive-threat-protection-ecosystem/)
+|[Damballa Failsafe](http://www.damballa.com/)|[Damballa, Inc.](http://www.damballa.com/)|Damballa Failsafe analyzes network traffic and automatically detects infected devices after other security controls have failed; security teams receive actionable and prioritized intelligence so they can take immediate action to prevent data theft|&#x2713;|-|None available|
 |[hailataxii.com Repository of Open Source Cyber Threat Intelligence Feeds in STIX Format](http://hailataxii.com/)|[Hail a TAXII](http://hailataxii.com)|Repository of open source cyber threat intelligence feeds in STIX format|&#x2713;|&#x2713;|[Cited as product features on website](http://hailataxii.com/)|
 |[InTELL Version 3.0](https://fox-it.com/intell)|[Fox-IT](https://fox-it.com)|Real-time contextual cyber intelligence|&#x2713;|&#x2713;|Cited as product features on website, [Press Release](https://www.fox-it.com/en/press-releases/fox-releases-intell-3-0-adding-stix-taxii-support-real-time-visualisations/)|
 |[Interflow](https://technet.microsoft.com/en-us/security/dn750892)|[Microsoft Corporation](http://www.microsoft.com)|Security and threat information exchange platform|&#x2713;|&#x2713;|Cited as product features on website, included in FAQ answers on website, [Press Release](http://blogs.technet.com/b/msrc/archive/2014/06/23/announcing-microsoft-interflow.aspx)|


### PR DESCRIPTION
Added (1) ICS-ISAC to USER COMMUNITIES table, and (2) Damballa and (3) Check Point products to PRODUCTS/SERVICES table.

Damballa make no reference to how they use STIX in their Type description, nor do there appear to be any public reference URLs available, so their listing will hopefully be updated at somepoint otherwise there is no explanation for the check mark in the STIX column.